### PR TITLE
Enable pre-commit hook updates in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,14 @@
     {
       "groupName": "requirements.txt",
       "matchPaths": ["requirements.txt"]
+    },
+    {
+      "groupName": "pre-commit",
+      "matchManagers": ["pre-commit"]
     }
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "schedule": ["on the first day of the month"]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,3 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-
-ci:
-  autoupdate_schedule: quarterly


### PR DESCRIPTION
https://docs.renovatebot.com/modules/manager/pre-commit/

Complementary to https://github.com/hugovk/hugovk/pull/15

With this config in place, pre-commit.ci integration won't be necessary (https://github.com/hugovk/hugovk/pull/15#pullrequestreview-3515917439)